### PR TITLE
Remove unnecessary right padding

### DIFF
--- a/src/assets/css/librarybrowser.scss
+++ b/src/assets/css/librarybrowser.scss
@@ -1172,7 +1172,7 @@ div:not(.sectionTitleContainer-cards) > .sectionTitle-cards {
 
 @media all and (min-height: 31.25em) {
     .padded-right-withalphapicker {
-        padding-right: 7.5%;
+        padding-right: 3.3%;
     }
 }
 


### PR DESCRIPTION
There isn't any reason the right should be padded more than the left, even with letters and numbers displayed.
